### PR TITLE
Make sure to reset client subscriptions before (re)starting them

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,6 @@
   "scripts": {
     "build": "[ \"$WATCH\" == 'true' ] && rollup -cw || rollup -c",
     "watch": "WATCH=true npm run build",
-    "test": "JASMINE_CONFIG_PATH='spec/node/support/jasmine.json' jasmine",
     "prebuild": "rm -rf dist",
     "prepublish": "npm run build"
   },

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -116,7 +116,13 @@ class PublicationClient extends EventEmitter {
    * @returns {Promise}
    */
   whenConnected() {
-    return this._whenConnected;
+    return new Promise((resolve) => {
+      if (this._isConnected) {
+        resolve();
+      } else {
+        this.once('connected', resolve);
+      }
+    });
   }
 
   /**

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -110,7 +110,7 @@ class PublicationClient extends EventEmitter {
   }
 
   /**
-   * Returns a promise that will be resolved once the the publicated provider
+   * Returns a promise that will be resolved once the the publication provider
    * acknowledges to us that we are `connected`.
    *
    * @returns {Promise}

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -70,6 +70,7 @@ class PublicationClient extends EventEmitter {
 
       this._connect();
       _.each(this._subscriptions, (sub) => {
+        sub._reset();
         sub._start();
       });
     });


### PR DESCRIPTION
Previously, on reconnection, a subscription would be restarted without
resetting `_isReady`, hence any clients that observed the reconnection event
would see a repeat call to `whenReady` resolve too early.

Also implement `PublicationClient#whenConnected` since turns out it wasn't. 🙈 