### PR TITLE
MX-581 Re-broadcast all messages received

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -100,15 +100,11 @@ class PublicationClient extends EventEmitter {
         break;
       case 'connected':
         this._isConnected = true;
-        this.emit('connected');
-        break;
-      case 'ready':
-        this.emit('ready', msg);
-        break;
-      default:
-        this.emit(msg.msg, msg);
         break;
     }
+
+    // Relay all messages received.
+    this.emit(msg.msg, msg);
   }
 
   /**


### PR DESCRIPTION
Updated the `_handleMessage` function to re-broadcast all messages received.