### PR TITLE
Upgrade Primus and uws for node 10 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -187,13 +187,13 @@
       }
     },
     "access-control": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/access-control/-/access-control-1.0.0.tgz",
-      "integrity": "sha1-rrooLO53MT6FJAFj1p41sp421iY=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/access-control/-/access-control-1.0.1.tgz",
+      "integrity": "sha512-H5aqjkogmFxfaOrfn/e42vyspHVXuJ8er63KuljJXpOyJ1ZO/U5CrHfO8BLKIy2w7mBM02L5quL0vbfQqrGQbA==",
       "requires": {
-        "millisecond": "0.1.x",
-        "setheader": "0.0.x",
-        "vary": "1.1.x"
+        "millisecond": "~0.1.2",
+        "setheader": "~1.0.0",
+        "vary": "~1.1.0"
       }
     },
     "acorn": {
@@ -408,18 +408,21 @@
       "dev": true
     },
     "color": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
-      "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
       "requires": {
-        "color-convert": "^0.5.0",
-        "color-string": "^0.3.0"
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
       }
     },
     "color-convert": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-      "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
     },
     "color-name": {
       "version": "1.1.3",
@@ -427,25 +430,26 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "requires": {
-        "color-name": "^1.0.0"
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
       }
     },
     "colornames": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
-      "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
     },
     "colorspace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
-      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
       "requires": {
-        "color": "0.8.x",
-        "text-hex": "0.0.x"
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
       }
     },
     "concat-map": {
@@ -478,11 +482,11 @@
       "dev": true
     },
     "create-server": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/create-server/-/create-server-1.0.1.tgz",
-      "integrity": "sha1-FkNCg08Yi77Hx7xGZ0Y8wrEwTEQ=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/create-server/-/create-server-1.0.2.tgz",
+      "integrity": "sha512-hie+Kyero+jxt6dwKhLKtN23qSNiMn8mNIEjTjwzaZwH2y4tr4nYloeFrpadqV+ZqV9jQ15t3AKotaK8dOo45w==",
       "requires": {
-        "connected": "0.0.x"
+        "connected": "~0.0.2"
       }
     },
     "cross-spawn": {
@@ -495,11 +499,6 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
-    },
-    "debug": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-      "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -518,13 +517,26 @@
       }
     },
     "diagnostics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.0.tgz",
-      "integrity": "sha1-4QkJALSVI+hSe+IPCBJ1IF8q42o=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-gvnlQHwkWTOeSM1iRNEwPcUuUwlhovzbuQzalKrTbcJhI5cvhtkRVZZqomwZt4pCl2dvbsugD6yyu+66rtMy3Q==",
       "requires": {
-        "colorspace": "1.0.x",
-        "enabled": "1.0.x",
-        "kuler": "0.0.x"
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0",
+        "storage-engine": "3.0.x"
+      },
+      "dependencies": {
+        "enabled": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+          "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+        },
+        "kuler": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+          "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+        }
       }
     },
     "doctrine": {
@@ -571,9 +583,9 @@
       }
     },
     "env-variable": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.4.tgz",
-      "integrity": "sha512-+jpGxSWG4vr6gVxUHOc4p+ilPnql7NzZxOZBxNldsKGjCF+97df3CbuX7XMaDa5oAVkKQj4rKp38rYdC4VcpDg=="
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
+      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA=="
     },
     "es-abstract": {
       "version": "1.13.0",
@@ -795,9 +807,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "extendible": {
       "version": "0.1.1",
@@ -1039,6 +1051,11 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
@@ -1143,11 +1160,11 @@
       }
     },
     "kuler": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
-      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
       "requires": {
-        "colornames": "0.0.2"
+        "colornames": "^1.1.1"
       }
     },
     "levn": {
@@ -1232,6 +1249,11 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nanoid": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.4.tgz",
+      "integrity": "sha512-sOJnBmY3TJQBVIBqKHoifuwygrocXg3NjS9rZSMnVl05XWSHK7Qxb177AIZQyMDjP86bz+yneozj/h9qsPLcCA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -1392,20 +1414,20 @@
       "dev": true
     },
     "primus": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/primus/-/primus-6.1.0.tgz",
-      "integrity": "sha1-s79Mk46weHS4crwrDOnA2oVdbBI=",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/primus/-/primus-7.3.3.tgz",
+      "integrity": "sha512-e/w6bY8I/7Y7gWV/yew9rodf682wNP0sGnHiXstf3WIndzMFBqOwKdbkr89w4MfdaUvZ3SkwwGGieDKuVVSPmQ==",
       "requires": {
         "access-control": "~1.0.0",
         "asyncemit": "~3.0.1",
         "create-server": "~1.0.1",
-        "diagnostics": "~1.1.0",
-        "eventemitter3": "~2.0.2",
+        "diagnostics": "~2.0.0",
+        "eventemitter3": "~3.1.0",
         "forwarded-for": "~1.0.1",
         "fusing": "~1.0.0",
-        "setheader": "~0.0.4",
-        "ultron": "~1.1.0",
-        "yeast": "~0.1.2"
+        "nanoid": "~2.0.0",
+        "setheader": "~1.0.0",
+        "ultron": "~1.1.0"
       }
     },
     "process-nextick-args": {
@@ -1544,11 +1566,23 @@
       "dev": true
     },
     "setheader": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/setheader/-/setheader-0.0.4.tgz",
-      "integrity": "sha1-km7SjPdiFJYgkx566j8blYFuxpQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/setheader/-/setheader-1.0.1.tgz",
+      "integrity": "sha512-iNDik8ipRBZHfpbpdWlhfZxc0JM9Cg4NYo8jqBkjSRLPxvcgnrE9oiF3AhpFvypg2erVyWNS+QhykhQt0G9tpA==",
       "requires": {
-        "debug": "0.7.x"
+        "diagnostics": "1.x.x"
+      },
+      "dependencies": {
+        "diagnostics": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+          "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+          "requires": {
+            "colorspace": "1.1.x",
+            "enabled": "1.0.x",
+            "kuler": "1.0.x"
+          }
+        }
       }
     },
     "shebang-command": {
@@ -1571,6 +1605,14 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -1605,6 +1647,27 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "storage-engine": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/storage-engine/-/storage-engine-3.0.7.tgz",
+      "integrity": "sha512-V/jJykpPdsyDImLwu19syIAWn/Tb41tBDikQS+aQPH2h2OgqdLxwOg7wI9nPH3Y0Mh1ce566JZl2u+4eH1nAsg==",
+      "requires": {
+        "enabled": "^2.0.0",
+        "eventemitter3": "^4.0.0"
+      },
+      "dependencies": {
+        "enabled": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+          "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+        },
+        "eventemitter3": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+        }
+      }
     },
     "string-width": {
       "version": "2.1.1",
@@ -1690,9 +1753,9 @@
       }
     },
     "text-hex": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
-      "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
     "text-table": {
       "version": "0.2.0",
@@ -1776,9 +1839,9 @@
       "dev": true
     },
     "uws": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-0.14.1.tgz",
-      "integrity": "sha1-ibjre87ScsZWIUcuh4xX9ODgBkA="
+      "version": "10.148.1",
+      "resolved": "https://registry.npmjs.org/uws/-/uws-10.148.1.tgz",
+      "integrity": "sha1-/Rp5z2EYo4jgob7YoTlwMNLE/Sw="
     },
     "vary": {
       "version": "1.1.2",
@@ -1820,11 +1883,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "dependencies": {
     "ejson": "^2.1.2",
     "node-uuid": "^1.4.7",
-    "primus": "^6.0.8",
+    "primus": "^7.3.3",
     "underscore": "^1.8.3",
-    "uws": "0.14.1"
+    "uws": "^10.148.1"
   },
   "devDependencies": {
     "eslint": "^5.15.3",


### PR DESCRIPTION
Previously, this library used uws@0.14.3 which didn't have bindings for linux 64 or darwin 64 ABIs. Prior to node 10, this wasn't a problem since process.versions.modules` did not support 64 ABIs. However, with upgrades to node 10 and V8, 64 ABIs are now supported.

The latest releases of `uws` (10.148.1) has 64 ABI bindings, and the latest version of `primus` (7.3.3) supports the latest version of uws ([based on their dev dependencies](https://github.com/primus/primus/blob/7.3.3/package.json#L93)).

Looking at the latest [major version change](https://github.com/primus/primus/releases/tag/7.0.0) of primus, it looks like they changed 2 options:
* 1 when initializing the server which is inaccessible outside this library
* 1 when [initializing the client](https://github.com/primus/primus/tree/7.3.3#connecting-from-the-browser) which _is_ accessible outside the library

The latter only applies to `publication-client` so we'll have to make a major version change there, but `publication-server` can be transparently upgraded.

I tested this by starting the publication server locally on node 10 without the above changes where it failed, and then starting it with the changes where it passed :) 