### PR TITLE
Remove the pingInterval

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,8 @@ class PublicationServer {
       authorization: this._authFn,
       pathname: this._mountPath,
       parser: 'EJSON',
-      transformer: 'uws'
+      transformer: 'uws',
+      pingInterval: false
     });
 
     this._primus.on('connection', (spark) => {


### PR DESCRIPTION
Since we don't use the timeout strategy in the publication-client, we
can remove the pingInterval in favor of our own ping/pong
implementations.