### PR TITLE
Fix documentation around ReactiveQuery callbacks

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -164,10 +164,10 @@ To listen for changes that match a provided query:
 ```js
 client.getCollection('baz').find({
   _id: 'foo'
-}).on('added', (doc) => {
-  console.log(`added a new document: ${doc}`);
-}).on('changed', (doc, changes) => {
-  console.log(`document with id ${doc._id} has changes: ${changes}`);
+}).on('added', (id, fields) => {
+  console.log(`added a new document: ${Object.assign({}, {id}, fields)}`);
+}).on('changed', (id, changes) => {
+  console.log(`document with id ${id} has changes: ${changes}`);
 }).on('removed', (id) => {
   console.log(`removed document with id: ${id}`);
 });


### PR DESCRIPTION
The previous documentation was not aligned with the query
https://github.com/mixmaxhq/publication-server/blob/master/client/src/reactiveQuery.js#L36
though it is aligned with the linked `Mongo.Cursor.observeChanges` documentation
https://docs.meteor.com/api/collections.html#Mongo-Cursor-observeChanges.